### PR TITLE
Github Profile Image Scrapper

### DIFF
--- a/GitHub Profile Image/scrapper.py
+++ b/GitHub Profile Image/scrapper.py
@@ -1,0 +1,21 @@
+import requests;
+import webbrowser;
+from bs4 import BeautifulSoup as bs;
+
+githubUsername = input("Enter the GitHub Username : ");
+url = 'https://github.com/' + githubUsername;
+
+# requesting the data for the url
+requestData = requests.get(url);
+
+# parsing the data using the beautiful soup library
+parsedData = bs(requestData.content, 'html.parser');
+
+# getting the profile image link from the parsed data
+profileImageUrl = parsedData.find('img',{'alt' : "Avatar"})['src'];
+
+# displaying the profile image link
+print("Link to the profile Image :" + profileImageUrl);
+
+# code to open a image url in a new browser tab
+webbrowser.open(profileImageUrl, new=2)


### PR DESCRIPTION
## Created the Github Profile Image Scrapper

## Libraries Used : 
 - webbrowser
 - requests
 - BeautfulSoup

## Screenshots

**Displaying the profile image url in the console**

![Screenshot from 2022-10-01 19-10-52](https://user-images.githubusercontent.com/97543666/193412357-5370d551-cf1d-46f9-b799-e5db11b59fa1.png)

**Opening the profile image url in a new tab**
![Screenshot from 2022-10-01 19-10-46](https://user-images.githubusercontent.com/97543666/193412354-44fff5cc-9f5e-4a1c-a5e2-3b71d9021623.png)


